### PR TITLE
Add example warning banner.

### DIFF
--- a/global.rst
+++ b/global.rst
@@ -10,3 +10,8 @@
 
 .. role:: underline-bold
     :class: underline-bold
+
+.. warning:: 
+
+    This documentation is for a pilot service. 
+    It is likely incomplete or may be inaccurate as the service environment is developed.


### PR DESCRIPTION
This is just an example (and can be edited to say w/e.) This will add the warning banner at the top of every page in the site.