### PR TITLE
Tox whitelist_externals depreciated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 [testenv]
 deps =
     -r requirements.txt
-whitelist_externals =
+allowlist_externals = 
     make
     echo
 commands =


### PR DESCRIPTION
Replaces depreciated `whitelist_externals` with `allowlist_externals`.